### PR TITLE
Renaming models

### DIFF
--- a/examples/example_ptZ_PerBin_CMAES.yml
+++ b/examples/example_ptZ_PerBin_CMAES.yml
@@ -24,7 +24,7 @@ input:
 
 #############################
 model:
-  type: 'DirectModel'
+  type: 'PerBinModel'
   seed: 0
 
   noscan_setup:

--- a/examples/example_ptZ_PerBin_Grad.yml
+++ b/examples/example_ptZ_PerBin_Grad.yml
@@ -24,7 +24,7 @@ input:
 
 #############################
 model:
-  type: 'DirectModel'
+  type: 'PerBinModel'
   seed: 0
 
   noscan_setup:

--- a/examples/reference_tune_AZ_Pythia8/reference_tune_phi.yml
+++ b/examples/reference_tune_AZ_Pythia8/reference_tune_phi.yml
@@ -27,7 +27,7 @@ input:
 
 #############################
 model:
-  type: 'DirectModel'
+  type: 'PerBinModel'
   seed: 0
 
   noscan_setup:

--- a/examples/reference_tune_AZ_Pythia8/reference_tune_ptZ.yml
+++ b/examples/reference_tune_AZ_Pythia8/reference_tune_ptZ.yml
@@ -27,7 +27,7 @@ input:
 
 #############################
 model:
-  type: 'DirectModel'
+  type: 'PerBinModel'
   seed: 0
 
   noscan_setup:

--- a/examples/reference_tune_AZ_Pythia8/reference_tune_ptZphi.yml
+++ b/examples/reference_tune_AZ_Pythia8/reference_tune_ptZphi.yml
@@ -29,7 +29,7 @@ input:
 
 #############################
 model:
-  type: 'DirectModel'
+  type: 'PerBinModel'
   seed: 0
 
   noscan_setup:

--- a/src/mcnntunes/app.py
+++ b/src/mcnntunes/app.py
@@ -135,7 +135,7 @@ class App(object):
             # Save to disk
             benchmark_data.save(self.BENCHMARK_DATA % self.args.output)
 
-        if self.config.model_type == 'DirectModel':
+        if self.config.model_type == 'PerBinModel':
             show('\n- You can now proceed with the {model} mode with bins=[1,%d]' % runs.y.shape[1])
         else:
             show('\n- You can now proceed with the {model} mode')
@@ -267,7 +267,7 @@ class App(object):
                 current_output_path = None
 
             # Get the predicted parameters, discriminating between direct and inverse models
-            if model_type == 'DirectModel':
+            if model_type == 'PerBinModel':
 
                 # Minimizer choice
                 if minimizer_type == 'CMAES':
@@ -360,7 +360,7 @@ class App(object):
         nn.search_and_load_model(f'{self.args.output}/{self.config.model_type}')
 
         # Get the predicted parameters, discriminating between direct and inverse models
-        if self.config.model_type == 'DirectModel':
+        if self.config.model_type == 'PerBinModel':
 
             # Minimizer choice
             if self.config.minimizer_type == 'CMAES':
@@ -384,7 +384,7 @@ class App(object):
         info('\n [======= Result Summary =======]')
 
         # print best parameters
-        if self.config.model_type == 'DirectModel':
+        if self.config.model_type == 'PerBinModel':
             if self.config.use_weights:
                 show('\n- Suggested best parameters for (weighted) chi2/dof = %.6f' % chi2)
             else:
@@ -395,7 +395,7 @@ class App(object):
             show('  =] (%e +/- %e) = %s' % (best_x[i], best_std[i], p))
 
         # print correlation matrix (if using CMA-ES)
-        if self.config.model_type == 'DirectModel' and self.config.minimizer_type == 'CMAES':
+        if self.config.model_type == 'PerBinModel' and self.config.minimizer_type == 'CMAES':
 
             result = m.get_fmin_output()
 
@@ -431,7 +431,7 @@ class App(object):
         display_output['summary'] = pickle.load(open('%s/data/summary.p' % self.args.output, 'rb'))
 
         # Switch case
-        if display_output['model_type'] == 'DirectModel':
+        if display_output['model_type'] == 'PerBinModel':
 
             display_output['minimizer_type'] = self.config.minimizer_type
 

--- a/src/mcnntunes/nnmodel.py
+++ b/src/mcnntunes/nnmodel.py
@@ -55,20 +55,20 @@ class Model(ABC):
         pass
 
 
-class DirectModel(Model):
+class PerBinModel(Model):
     """This model predicts the MC run output giving the input parameters."""
 
     def __init__(self, runs, seed = 0):
         """Set data attributes"""
         Model.__init__(self, runs, seed = 0)
-        self.model_type = 'DirectModel'
+        self.model_type = 'PerBinModel'
 
     def build_and_train_model(self, setup):
         """Build and train n_bins FullyConnected models"""
 
         self.per_bin_nns = []
         for bin in range(1, self.runs.y.shape[1]+1):
-            nn = PerBinModel(self.seed)
+            nn = SingleBinModel(self.seed)
             show(f'\n- Fitting bin {bin}')
             nn.fit(self.runs.x_scaled, self.runs.y_scaled[:,bin-1], setup)
             self.per_bin_nns.append(nn)
@@ -96,7 +96,7 @@ class DirectModel(Model):
 
         self.per_bin_nns = []
         for bin in range(1, self.runs.y.shape[1]+1):
-            nn = PerBinModel()
+            nn = SingleBinModel()
             nn.model, nn.fixed_setup, nn.loss = load(f'{input_path}/model_bin_{bin}/model.h5')
             self.per_bin_nns.append(nn)
 
@@ -120,7 +120,7 @@ class DirectModel(Model):
         return prediction
 
 
-class PerBinModel(object):
+class SingleBinModel(object):
 
     def __init__(self, seed = 0):
         """Allocate random seed"""
@@ -303,8 +303,8 @@ class InverseModel(Model):
 
 def get_model(model_type, runs, seed = 0):
     """Return a Model object, discriminating between different model type"""
-    if model_type == 'DirectModel':
-        return DirectModel(runs, seed)
+    if model_type == 'PerBinModel':
+        return PerBinModel(runs, seed)
     elif model_type == 'InverseModel':
         return InverseModel(runs, seed)
     else:

--- a/src/mcnntunes/runcardio.py
+++ b/src/mcnntunes/runcardio.py
@@ -18,13 +18,13 @@ class Config(object):
         input:
             folders: folders containing the MC runs;
             patterns: list of patterns to look for in the MC runs histograms paths;
-            unpatters: list of patterns to exclude during the runs loading;
+            unpatters: list of patterns to exclude;
             expfiles: list of files with the reference data;
             benchmark_folders: folders containing the MC runs used as benchmark for the tuning procedure;
             weightrules: a list of weight modifiers (optional)
                 - pattern: it selects the histograms with that pattern in the path
                   condition: see below
-                  weight: the weight
+                  weight: the weight (only 0 or 1 for the InverseModel)
                 - ...
 
     The condition subkey accept only:
@@ -33,7 +33,7 @@ class Config(object):
        It's also possible to use '+inf' or '-inf' instead a real numbers.
 
         model:
-            model_type: 'DirectModel' or 'InverseModel'
+            model_type: 'PerBinModel' or 'InverseModel'
             seed:
             noscan_setup:
                 architecture: (optional, default [5, 5])
@@ -44,12 +44,13 @@ class Config(object):
                 epochs: (optional, default 5000)
                 batch_size: (optional, default 16)
                 data_augmentation: (optional, default False, only for 'InverseModel')
-                param_estimator:(optional, only for 'InverseModel', 'SimpleInference', 'Median', 'Mean')
+                param_estimator:(optional, only for 'InverseModel', 'SimpleInference',
+                                    'Median', 'Mean', default 'SimpleInference')
 
-        minimizer: (only for 'DirectModel')
+        minimizer: (only for 'PerBinModel')
             minimizer_type: 'CMAES' or 'GradientMinimizer' (experimental)
-            bounds: (only for CMAES)
-            restarts: (only for CMAES)
+            bounds: boolean, bounds the results to be within the steering ranges (only for CMAES)
+            restarts: number of minimization trials (only for CMAES)
 
         hyperparameter_scan:
             max_evals:
@@ -133,7 +134,7 @@ class Config(object):
         self.noscan_setup = self.get('model', 'noscan_setup')
 
         # Minimizer subsection
-        if self.model_type == 'DirectModel':
+        if self.model_type == 'PerBinModel':
             self.minimizer_type = self.get('minimizer', 'type')
             if self.minimizer_type == 'CMAES':
                 self.bounds = self.get('minimizer','bounds')

--- a/src/mcnntunes/templates/data.html
+++ b/src/mcnntunes/templates/data.html
@@ -3,7 +3,7 @@
 {% block body %}
 <h1 class="page-title">Data/Model</h1>
 <div class="markdown-body">
-    {% if model_type is eq('DirectModel') %}
+    {% if model_type is eq('PerBinModel') %}
     <figure>
         {% for n in range(data_hists) %}
         <img src="plots/{{n}}_data.svg" alt="data">

--- a/src/mcnntunes/templates/index.html
+++ b/src/mcnntunes/templates/index.html
@@ -27,7 +27,7 @@
         </tbody>
     </table>
 
-    {% if model_type is eq('DirectModel') %}
+    {% if model_type is eq('PerBinModel') %}
     {% if minimizer_type is eq('CMAES') %}
     <h2>Correlation matrix</h2>
     <figure>
@@ -42,7 +42,7 @@
         <thead>
         <tr>
             <th scope="col">Item</th>
-            {% if model_type is eq('DirectModel') %}
+            {% if model_type is eq('PerBinModel') %}
             <th scope="col">Model</th>
             {% endif %}
             <th scope="col">Min. MC runs</th>
@@ -53,7 +53,7 @@
         {% for row in summary %}
         <tr>
             <td>{{row.name}}</td>
-            {% if model_type is eq('DirectModel') %}
+            {% if model_type is eq('PerBinModel') %}
             <td>{{row.model}}</td>
             {% endif %}
             <td>{{row.min}}</td>

--- a/src/mcnntunes/templates/minimization.html
+++ b/src/mcnntunes/templates/minimization.html
@@ -4,7 +4,7 @@
 <h1 class="page-title">Minimization</h1>
 <div class="markdown-body">
 
-    {% if model_type is eq('DirectModel') %}
+    {% if model_type is eq('PerBinModel') %}
 
         {% if weighted_chi2 is defined %}
             <p>Final (weighted) chi2/dof: {{weighted_chi2}} (dof={{weighted_dof}})<br>

--- a/src/mcnntunes/templates/model.html
+++ b/src/mcnntunes/templates/model.html
@@ -3,7 +3,7 @@
 {% block body %}
 <div class="markdown-body">
 
-    {% if model_type is eq('DirectModel') %}
+    {% if model_type is eq('PerBinModel') %}
     
     <h2>Model vs MC runs uncertainties</h2>
     <figure>


### PR DESCRIPTION
When I implemented the models I used the name "PerBinModel" for the single neural network that parametrises a single bin, and "DirectModel" for the whole model made of many "PerBinModel".

In this PR I renamed the models following the names used in the paper:

- `DirectModel` -> `PerBinModel`
- `PerBinModel` -> `SingleBinModel`
