### PR TITLE
Update Python versions in CI

### DIFF
--- a/.github/workflows/Tests.yml
+++ b/.github/workflows/Tests.yml
@@ -2,7 +2,7 @@
 name: Tests
 on: push
 env:
-  yoda-filename: YODA-1.9.1
+  yoda-filename: YODA-1.9.4
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/Tests.yml
+++ b/.github/workflows/Tests.yml
@@ -9,7 +9,7 @@ jobs:
     timeout-minutes: 60
     strategy:
       matrix:
-        python-version: [3.6, 3.7, 3.8]
+        python-version: ["3.7", "3.8", "3.9", "3.10"]
     steps:
     - uses: actions/checkout@v2
     - name: Set up Python ${{ matrix.python-version }}

--- a/.github/workflows/Tests.yml
+++ b/.github/workflows/Tests.yml
@@ -9,7 +9,7 @@ jobs:
     timeout-minutes: 60
     strategy:
       matrix:
-        python-version: ["3.7", "3.8", "3.9", "3.10"]
+        python-version: ["3.7", "3.8", "3.9"]
     steps:
     - uses: actions/checkout@v2
     - name: Set up Python ${{ matrix.python-version }}


### PR DESCRIPTION
I removed Python 3.6 (no longer supported) from the CI and replaced it with v3.9. I also updated the YODA version.